### PR TITLE
Look for the forced version file before failing with scm checks

### DIFF
--- a/src/versionMain.cpp
+++ b/src/versionMain.cpp
@@ -129,6 +129,15 @@ int main(int argc, char* argv[])
     cerr << "                build  directory: \"" << binary_dir << "\"" << endl;
 
     atexit(finish);
+	
+    ifstream versionhforce( (binary_dir + versionFileName + ".force").c_str() );
+    if(versionhforce)
+    {
+        cerr << "                the file \"" + versionFileName + ".force\" does exist." << endl;
+        cerr << "                i will not change \"" + versionFileName + "\"." << endl;
+        versionhforce.close();
+        return 0;
+    }
 
     ifstream bzr( (source_dir + ".bzr/branch/last-revision").c_str() );
     const int bzr_errno = errno;
@@ -217,15 +226,6 @@ int main(int argc, char* argv[])
 
         svn >> revision; // "last revision"
         svn.close();
-    }
-
-    ifstream versionhforce( (binary_dir + versionFileName + ".force").c_str() );
-    if(versionhforce)
-    {
-        cerr << "                the file \"" + versionFileName + ".force\" does exist." << endl;
-        cerr << "                i will not change \"" + versionFileName + "\"." << endl;
-        versionhforce.close();
-        return 0;
     }
 
     ifstream versionh( (binary_dir + versionFileName).c_str() );


### PR DESCRIPTION
This is part of @susnux's https://build.opensuse.org/package/view_file/games/s25rttr/s25rttr-fix-version.patch?expand=1 and essential for the override to work at all, because otherwise the build will fail at https://github.com/Return-To-The-Roots/version/blob/f6598d5/src/versionMain.cpp#L151